### PR TITLE
fix(ci): switch release-please to simple strategy for workspace versions

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "rust",
   "packages": {
     ".": {
+      "release-type": "simple",
       "package-name": "pisovereign",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,


### PR DESCRIPTION
The Rust strategy fails with 'value at path package.version is not tagged' because crates use `version.workspace = true` inheritance. The simple strategy with TOML extra-files properly handles updating the workspace version in root Cargo.toml.

Changes:
- Move release-type from global to package level
- Change release-type from 'rust' to 'simple'
- Keep extra-files config for workspace.package.version