### PR TITLE
fix(ci): enhance cross-compilation setup for ARM64 with OpenSSL support

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,6 +28,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 # Cancel in-progress runs for the same workflow/ref
 concurrency:
@@ -140,19 +141,38 @@ jobs:
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          # Install OpenSSL for cross-compilation
+          sudo dpkg --add-architecture arm64
+          sudo sed -i 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $(lsb_release -cs) main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/arm64.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $(lsb_release -cs)-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/arm64.list
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev:arm64
 
       - name: Configure cross-compilation (Linux ARM64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
           echo "[target.aarch64-unknown-linux-gnu]" >> ~/.cargo/config.toml
           echo "linker = \"aarch64-linux-gnu-gcc\"" >> ~/.cargo/config.toml
+        env:
+          PKG_CONFIG_ALLOW_CROSS: 1
+          PKG_CONFIG_PATH: /usr/lib/aarch64-linux-gnu/pkgconfig
+          OPENSSL_DIR: /usr
+          OPENSSL_LIB_DIR: /usr/lib/aarch64-linux-gnu
+          OPENSSL_INCLUDE_DIR: /usr/include
 
       - name: Build release binaries
         run: |
           cargo build --release --target ${{ matrix.target }} \
             -p presentation_cli \
             -p presentation_http
+        env:
+          PKG_CONFIG_ALLOW_CROSS: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && '1' || '' }}
+          PKG_CONFIG_PATH: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && '/usr/lib/aarch64-linux-gnu/pkgconfig' || '' }}
+          OPENSSL_DIR: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && '/usr' || '' }}
+          OPENSSL_LIB_DIR: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && '/usr/lib/aarch64-linux-gnu' || '' }}
+          OPENSSL_INCLUDE_DIR: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && '/usr/include' || '' }}
 
       - name: Package binaries
         run: |


### PR DESCRIPTION
This pull request improves the GitHub Actions workflow for release automation, specifically enhancing the cross-compilation setup for Linux ARM64 targets. The main changes focus on ensuring proper installation of dependencies and configuring environment variables for successful builds.

Cross-compilation improvements for ARM64:

* Added installation steps for `g++-aarch64-linux-gnu` and `libssl-dev:arm64`, including configuration of Ubuntu sources to support ARM64 packages.
* Set environment variables (`PKG_CONFIG_ALLOW_CROSS`, `PKG_CONFIG_PATH`, `OPENSSL_DIR`, `OPENSSL_LIB_DIR`, `OPENSSL_INCLUDE_DIR`) for both the cross-compilation configuration and build steps to ensure OpenSSL and pkg-config work correctly when targeting ARM64.

Workflow permissions update:

* Added `actions: write` permission to the workflow to enable actions management.