### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,8 @@ jobs:
   ci-success:
     name: CI Success
     needs: [fmt, clippy, test, coverage, build, doc]
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: always()
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/twohreichel/PiSovereign/security/code-scanning/7](https://github.com/twohreichel/PiSovereign/security/code-scanning/7)

In general, to fix this issue, you add an explicit `permissions` block either at the workflow root (applies to all jobs without their own permissions) or on the specific job flagged by CodeQL, granting only the minimal scopes needed. For the `ci-success` job, it only needs to read job results via the `needs` context, which does not require any GitHub API permissions, so we can safely restrict `GITHUB_TOKEN` to read‑only repository contents (or even `permissions: {}` which fully disables it).

The most targeted, non‑disruptive fix is to add a `permissions` block under the `ci-success` job definition in `.github/workflows/ci.yml`. This avoids potential impact on other jobs that might legitimately require additional permissions (for example, uploading coverage or artifacts). We will set `contents: read`, which is a standard minimal scope and satisfies the CodeQL recommendation. Concretely, in the `ci-success` job, between lines 214–215 (after `needs: [...]` and before `runs-on:`), insert:

```yaml
    permissions:
      contents: read
```

No imports, methods, or additional definitions are needed because this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
