### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@
 
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/twohreichel/PiSovereign/security/code-scanning/5](https://github.com/twohreichel/PiSovereign/security/code-scanning/5)

In general, the fix is to explicitly set `permissions` for the `GITHUB_TOKEN` in the workflow, preferably at the root so it applies to all jobs, and to restrict it to the minimum required scopes (here, read access to repository contents is sufficient). This documents the intended permissions and ensures the workflow does not accidentally gain broader rights if org defaults change.

The best targeted fix without changing functionality is to add a root-level `permissions` block right after the top-level `name: CI` declaration, before the `on:` section. None of the jobs in the provided snippet need to write to the repository or other resources via `GITHUB_TOKEN`; they only need to read the code (handled by `actions/checkout` using `contents: read`) and interact with external services using secrets (e.g., `CODECOV_TOKEN`). Therefore, we can safely set `permissions: contents: read`. If you later add jobs that need more access (e.g., `pull-requests: write`), they can override permissions per-job.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

between line 17 (`name: CI`) and line 19 (`on:`). No imports or additional methods are needed, as this is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
