### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/ci.yml"
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
Potential fix for [https://github.com/twohreichel/PiSovereign/security/code-scanning/3](https://github.com/twohreichel/PiSovereign/security/code-scanning/3)

In general, the fix is to explicitly set `permissions` for the `GITHUB_TOKEN` either at the workflow root (applies to all jobs) or individually per job, granting only the minimal scopes required. For this CI workflow, jobs only need to read the repository contents; they do not push commits, create releases, or modify issues/PRs. Therefore, `contents: read` at the workflow level is sufficient. If a future job needs broader access, it can override permissions locally.

The best minimal change is to add a root‑level `permissions` block just after the `on:` section (before `env:`) in `.github/workflows/ci.yml`:

```yaml
permissions:
  contents: read
```

This restricts `GITHUB_TOKEN` for all jobs (`fmt`, `clippy`, `test`, `coverage`, etc.) to read‑only repository contents, which is adequate for `actions/checkout` and any internal GitHub API reads. No other permissions (like `pull-requests` or `checks`) are required based on the provided snippet. No additional imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
