### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@
 
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/twohreichel/PiSovereign/security/code-scanning/2](https://github.com/twohreichel/PiSovereign/security/code-scanning/2)

In general, this should be fixed by explicitly scoping the `GITHUB_TOKEN` permissions either at the workflow root or per job. Since all shown jobs just need to read the repository contents, a minimal `permissions: contents: read` at the workflow level is appropriate; additional scopes can be added later if new jobs require them. This prevents the workflow from silently inheriting broader repository/organization defaults.

The best fix here without changing functionality is to add a root-level `permissions` block under the `name: CI` stanza, before `on:`. That block should set `contents: read`, which is sufficient for `actions/checkout` and any other code that only needs to read the repo. No job currently uses actions that write to PRs, issues, or releases, and they do not call GitHub’s REST API with `GITHUB_TOKEN`, so no other scopes are needed. All existing jobs (including `clippy`, where CodeQL pointed) will inherit the root permissions and continue to work as before, but now with explicit, limited privileges.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 18 (`name: CI`) and line 19 (`on:`). No imports or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
