### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ on:
       - "rust-toolchain.toml"
       - ".github/workflows/ci.yml"
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
Potential fix for [https://github.com/twohreichel/PiSovereign/security/code-scanning/1](https://github.com/twohreichel/PiSovereign/security/code-scanning/1)

In general, to fix this type of problem you add an explicit `permissions:` block either at the top level of the workflow (applies to all jobs) or per job, and grant only the scopes actually needed. For a pure CI workflow that checks out code and runs local tools, `contents: read` is typically sufficient.

For this specific file, the minimal, non‑intrusive fix is to add a top‑level `permissions:` block right after the `on:` section (before `env:`). This will apply to all jobs (`fmt`, `clippy`, `test`, etc.) that do not define their own `permissions:`. Based on the visible steps (checkout, toolchain setup, cargo commands, caching), they only need to read repository contents, so:

```yaml
permissions:
  contents: read
```

is appropriate. No additional imports or methods are needed; we are only modifying the YAML workflow definition. We do not need to touch the `fmt` job definition itself; adding the root `permissions:` resolves the CodeQL warning on line 53 by ensuring the `GITHUB_TOKEN` is restricted for that job and all others.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
