### PR TITLE
Remove redundant permissions declaration in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,6 @@ name: CI
 permissions:
   contents: read
 
-permissions:
-  contents: read
-
-permissions:
-  contents: read
-
 on:
   push:
     branches: [main]


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yml` file to clean up redundant permission declarations in the CI workflow configuration.