### PR TITLE
Potential fix for code scanning alert no. 104: Cleartext logging of sensitive information

### DIFF
--- a/crates/presentation_cli/src/migrate_keys.rs
+++ b/crates/presentation_cli/src/migrate_keys.rs
@@ -168,7 +168,7 @@ pub fn migrate_config(input_path: &Path, dry_run: bool) -> Result<MigrationResul
                                         });
                                         migrated += 1;
                                         println!(
-                                            "  ✅ Migrated plaintext hash → proper hash (user_id: {user_id})"
+                                            "  ✅ Migrated plaintext hash → proper hash"
                                         );
                                     },
                                     Err(e) => {


### PR DESCRIPTION
Potential fix for [https://github.com/twohreichel/PiSovereign/security/code-scanning/104](https://github.com/twohreichel/PiSovereign/security/code-scanning/104)

In general, to fix cleartext logging issues, avoid including sensitive values in logs; if identification is necessary, log only non‑sensitive metadata (counts, coarse status) or use a reversible/irreversible pseudonymization scheme depending on requirements. Here, the code logs the `user_id` directly in the CLI output when a plaintext “hash” is migrated. We can preserve functionality (informing the operator that something was migrated) without exposing `user_id` by either removing it from the message or replacing it with a non‑sensitive counter.

The minimal, behavior‑preserving change is to adjust the `println!` format string on the `Ok(new_hash)` path to no longer interpolate `{user_id}`. For example, change:

```rust
println!(
    "  ✅ Migrated plaintext hash → proper hash (user_id: {user_id})"
);
```

to something like:

```rust
println!("  ✅ Migrated plaintext hash → proper hash");
```

This keeps the success message and the migration counters (`migrated`, `failed`, etc.) intact but avoids printing `user_id`. No new imports or helper functions are needed, and no other lines in the file must change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
