### PR TITLE
Potential fix for code scanning alert no. 103: Cleartext logging of sensitive information

### DIFF
--- a/crates/presentation_cli/src/migrate_keys.rs
+++ b/crates/presentation_cli/src/migrate_keys.rs
@@ -126,7 +126,7 @@ pub fn migrate_config(input_path: &Path, dry_run: bool) -> Result<MigrationResul
                                     Err(e) => {
                                         failed += 1;
                                         println!(
-                                            "  ❌ Failed to hash key for user_id {user_id_str}: {e}"
+                                            "  ❌ Failed to hash key for an api_key_users entry: {e}"
                                         );
                                     },
                                 }


### PR DESCRIPTION
Potential fix for [https://github.com/twohreichel/PiSovereign/security/code-scanning/103](https://github.com/twohreichel/PiSovereign/security/code-scanning/103)

To fix the problem, remove or redact the potentially sensitive `user_id_str` from the `println!` call so that untrusted/sensitive data is not written to logs or stdout. The message can still indicate that hashing failed, and optionally include a non-sensitive hint (e.g., the position of the entry) if needed, but must not include the actual user identifier.

The single best minimal change is to modify the `println!` at lines 128–130 so it no longer interpolates `{user_id_str}`. Instead, log a generic failure message, or at most use safe, non-identifying context. This does not change control flow or error handling; it only alters the message text. No new imports or helper functions are needed.

Concretely, in `crates/presentation_cli/src/migrate_keys.rs`, within the `migrate_config` function’s `Err(e)` arm for hashing a non-hashed key in the `api_key_users` loop, replace:

```rust
println!(
    "  ❌ Failed to hash key for user_id {user_id_str}: {e}"
);
```

with something like:

```rust
println!("  ❌ Failed to hash key for an api_key_users entry: {e}");
```

This keeps the operational information that a key failed to hash while avoiding logging the specific user ID.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
