### PR TITLE
Potential fix for code scanning alert no. 101: Cleartext logging of sensitive information

### DIFF
--- a/crates/presentation_cli/src/migrate_keys.rs
+++ b/crates/presentation_cli/src/migrate_keys.rs
@@ -85,7 +85,7 @@ pub fn migrate_config(input_path: &Path, dry_run: bool) -> Result<MigrationResul
                                 });
                                 migrated += 1;
                                 println!(
-                                    "  ✅ Migrated legacy api_key → api_keys[0] (user_id: {default_user_id})"
+                                    "  ✅ Migrated legacy api_key → api_keys[0] (default user_id)"
                                 );
                             },
                             Err(e) => {


### PR DESCRIPTION
Potential fix for [https://github.com/twohreichel/PiSovereign/security/code-scanning/101](https://github.com/twohreichel/PiSovereign/security/code-scanning/101)

In general, to fix cleartext logging of sensitive information, either stop logging the sensitive field entirely or replace it with a non‑sensitive surrogate (e.g., a generic description, or a redacted/hashed form that cannot be reversed). For this case, the `println!` includes `user_id: {default_user_id}` in the message. Since `default_user_id` is treated as sensitive, the safest fix is to remove that interpolation from the log line or replace it with a generic description that does not expose the identifier.

The minimal, behavior‑preserving change is to adjust only the log message string at lines 87–89 so that it no longer prints `default_user_id`. The rest of the migration behavior (hashing, statistics, configuration changes) remains unchanged. We do not need any new imports or helper functions; it is a simple string change. For example, change:

```rust
println!(
    "  ✅ Migrated legacy api_key → api_keys[0] (user_id: {default_user_id})"
);
```

to something like:

```rust
println!("  ✅ Migrated legacy api_key → api_keys[0] (default user_id)");
```

or even just:

```rust
println!("  ✅ Migrated legacy api_key → api_keys[0]");
```

Either removes the sensitive value while still communicating what happened.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
