### PR TITLE
Potential fix for code scanning alert no. 107: Cleartext logging of sensitive information

### DIFF
--- a/crates/infrastructure/src/config/messenger.rs
+++ b/crates/infrastructure/src/config/messenger.rs
@@ -88,10 +88,13 @@ impl WhatsAppConfig {
         self.access_token.as_ref().map(ExposeSecret::expose_secret)
     }
 
-    /// Get the app secret as a string reference (for signature verification)
+    /// Get the app secret as a SecretString reference (for signature verification)
+    ///
+    /// Callers that need a `&str` must explicitly use `ExposeSecret::expose_secret`
+    /// at the call site, to avoid accidental cleartext logging.
     #[must_use]
-    pub fn app_secret_str(&self) -> Option<&str> {
-        self.app_secret.as_ref().map(ExposeSecret::expose_secret)
+    pub fn app_secret_str(&self) -> Option<&SecretString> {
+        self.app_secret.as_ref()
     }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/twohreichel/PiSovereign/security/code-scanning/107](https://github.com/twohreichel/PiSovereign/security/code-scanning/107)

In general, sensitive values stored in `SecretString` should not be exposed as raw `&str` or `String` where they can easily be logged or otherwise persisted. Instead, code that needs to use the secret should either work directly with `SecretString` or use a wrapper type that keeps the secret protected and discourages logging.

The best targeted fix here is to stop providing `app_secret` as a bare `&str`. We can change `app_secret_str` to return an `Option<&SecretString>` (or potentially remove it, but that might break callers). This keeps the secret wrapped in `SecretString` so that any code that wants to derive a `&str` must explicitly call `expose_secret()` itself, making those call sites more visible and reviewable. The rest of the API remains functionally equivalent for legitimate use (callers can still access the underlying secret), but the risk of accidental cleartext logging from this helper is reduced and CodeQL’s specific data‑flow path is cut.

Concretely, in `crates/infrastructure/src/config/messenger.rs`:

- Leave the storage of `app_secret: Option<SecretString>` unchanged.
- Modify the `impl WhatsAppConfig` block:
  - Change the return type of `app_secret_str` from `Option<&str>` to `Option<&SecretString>`.
  - Change the implementation from using `map(ExposeSecret::expose_secret)` to simply `self.app_secret.as_ref()`.
- The `access_token_str` method can remain as‑is unless CodeQL also flags it; the reported path is only for `app_secret`. If desired, the same pattern can be applied later for consistency.

No new imports or helper functions are required; we only adjust the signature and body of the existing method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
