### PR TITLE
Potential fix for code scanning alert no. 108: Disabled TLS certificate check

### DIFF
--- a/crates/integration_proton/src/tls.rs
+++ b/crates/integration_proton/src/tls.rs
@@ -23,9 +23,12 @@ pub fn build_native_tls_connector(
     // Configure certificate verification
     if !tls_config.should_verify() {
         warn!(
-            "⚠️ TLS certificate verification disabled - only recommended for local Proton Bridge"
+            "⚠️ TLS certificate verification requested to be disabled - this is no longer supported in this connector"
         );
-        builder.danger_accept_invalid_certs(true);
+        return Err(ProtonError::ConnectionFailed(
+            "TLS certificate verification cannot be disabled for Proton Bridge connections"
+                .to_string(),
+        ));
     } else if let Some(ca_cert_path) = &tls_config.ca_cert_path {
         // Load custom CA certificate
         debug!(path = %ca_cert_path.display(), "Loading custom CA certificate");


### PR DESCRIPTION
Potential fix for [https://github.com/twohreichel/PiSovereign/security/code-scanning/108](https://github.com/twohreichel/PiSovereign/security/code-scanning/108)

In general, the fix is to avoid disabling certificate validation on the shared `native_tls::TlsConnector` builder. Instead of calling `danger_accept_invalid_certs(true)` when `should_verify()` is false, we should either (a) always enforce verification here, or (b) surface an error when the configuration requests an unsupported “no verification” mode, pushing any truly unsafe behavior into separate, clearly test-only code. This preserves security while keeping configuration behavior explicit.

The best fix here, without changing existing successful connections or CA handling, is to remove the call to `danger_accept_invalid_certs(true)` and, if `tls_config.should_verify()` is false, return a `ProtonError` explaining that disabling verification is not supported in this path. This ensures the builder only ever creates connectors with certificate verification enabled (the default) or with a custom CA root while leaving the rest of the logic (custom CA loading, minimum TLS version) unchanged. Concretely, in `crates/integration_proton/src/tls.rs`, replace the `if !tls_config.should_verify() { ... } else if let Some(ca_cert_path)` block so that the `if` branch returns an error instead of mutating the builder, and keep the `else if` branch intact. No new imports or helper methods are required; we only use the existing `ProtonError::ConnectionFailed` and existing logging.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
