### PR TITLE
Potential fix for code scanning alert no. 109: Hard-coded cryptographic value

### DIFF
--- a/crates/integration_caldav/src/client.rs
+++ b/crates/integration_caldav/src/client.rs
@@ -740,10 +740,11 @@ mod tests {
 
     #[test]
     fn caldav_config_debug_redacts_password() {
-        let config = test_caldav_config("https://cal.example.com", "user", "supersecret", None);
+        let config =
+            test_caldav_config("https://cal.example.com", "user", "dummy-password-for-testing", None);
         let debug_output = format!("{config:?}");
         assert!(
-            !debug_output.contains("supersecret"),
+            !debug_output.contains("dummy-password-for-testing"),
             "Password must not appear in Debug output"
         );
         assert!(


### PR DESCRIPTION
Potential fix for [https://github.com/twohreichel/PiSovereign/security/code-scanning/109](https://github.com/twohreichel/PiSovereign/security/code-scanning/109)

General approach: avoid using realistic or production-like hard-coded secrets, even in tests. For this specific test, we only need a distinctive string to ensure it does not appear in Debug output; it does not need to be an actual password. We can replace `"supersecret"` with a clearly dummy value that indicates test usage, such as `"dummy-password-for-testing"`. The test’s behavior remains identical: it still checks that whatever password string is supplied does not appear in the debug output and that `[REDACTED]` does appear.

Best fix with minimal functional change: edit the `caldav_config_debug_redacts_password` test in `crates/integration_caldav/src/client.rs` so that the third argument to `test_caldav_config` is no longer `"supersecret"`, but some obviously dummy test value. To keep the code extremely simple and avoid additional definitions, we can directly replace the literal in place.

Concretely:
- In `crates/integration_caldav/src/client.rs`, locate the `caldav_config_debug_redacts_password` test.
- Change `"supersecret"` (line 743) to `"dummy-password-for-testing"`.
- No imports or other definitions are required; this is a straight string literal replacement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
