### PR TITLE
Potential fix for code scanning alert no. 113: Cleartext logging of sensitive information

### DIFF
--- a/crates/infrastructure/src/config/mod.rs
+++ b/crates/infrastructure/src/config/mod.rs
@@ -1108,15 +1108,15 @@ mod tests {
 
     #[test]
     fn whatsapp_config_app_secret_str() {
-        use secrecy::{ExposeSecret, SecretString};
+        use secrecy::SecretString;
 
         let config = WhatsAppConfig {
             app_secret: Some(SecretString::from("test_secret")),
             ..Default::default()
         };
         assert_eq!(
-            config.app_secret_str().map(ExposeSecret::expose_secret),
-            Some("test_secret")
+            config.app_secret_str(),
+            Some(SecretString::from("test_secret"))
         );
 
         let config_no_secret = WhatsAppConfig::default();


### PR DESCRIPTION
Potential fix for [https://github.com/twohreichel/PiSovereign/security/code-scanning/113](https://github.com/twohreichel/PiSovereign/security/code-scanning/113)

In general, to fix cleartext logging of sensitive information you should avoid converting secrets into plain strings when formatting or logging, or at least ensure they are redacted or handled via secure wrappers. Especially when using the `secrecy` crate, you should not call `ExposeSecret::expose_secret` in code paths that might reach logs or generic formatting.

For this specific issue, the test `whatsapp_config_app_secret_str` currently converts an optional `SecretString` into an exposed `&str` via `map(ExposeSecret::expose_secret)` only to compare it to `Some("test_secret")`. This explicit exposure is what the analyzer flags. We can keep the same functional check—verifying that `app_secret_str()` returns the expected value—by comparing the `Option<SecretString>` directly to `Some(SecretString::from("test_secret"))`, avoiding `ExposeSecret` entirely in this test. That way, no method that “exposes” the secret is called, and no secret is turned into a plain `&str`.

Concretely, in `crates/infrastructure/src/config/mod.rs`:
- In the `whatsapp_config_app_secret_str` test, remove the import of `ExposeSecret` (it will no longer be used).
- Change the assertion from:
  ```rust
  assert_eq!(
      config.app_secret_str().map(ExposeSecret::expose_secret),
      Some("test_secret")
  );
  ```
  to:
  ```rust
  assert_eq!(
      config.app_secret_str(),
      Some(SecretString::from("test_secret"))
  );
  ```
This preserves the intent (the getter returns the correct secret) without explicitly exposing the underlying string, and requires no new helper methods or external dependencies beyond `secrecy::SecretString`, which is already used in the test.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
