### PR TITLE
Potential fix for code scanning alert no. 114: Hard-coded cryptographic value

### DIFF
--- a/crates/integration_caldav/src/client.rs
+++ b/crates/integration_caldav/src/client.rs
@@ -724,6 +724,8 @@ mod tests {
         assert_eq!(config.username, "user");
     }
 
+    const DUMMY_PASSWORD: &str = "dummy-password-for-testing";
+
     #[test]
     fn caldav_config_serialization() {
         let config = test_caldav_config("https://cal.example.com", "user", "pass", None);
@@ -743,12 +745,12 @@ mod tests {
         let config = test_caldav_config(
             "https://cal.example.com",
             "user",
-            "dummy-password-for-testing",
+            DUMMY_PASSWORD,
             None,
         );
         let debug_output = format!("{config:?}");
         assert!(
-            !debug_output.contains("dummy-password-for-testing"),
+            !debug_output.contains(DUMMY_PASSWORD),
             "Password must not appear in Debug output"
         );
         assert!(


### PR DESCRIPTION
Potential fix for [https://github.com/twohreichel/PiSovereign/security/code-scanning/114](https://github.com/twohreichel/PiSovereign/security/code-scanning/114)

In general, to address hard-coded credential findings, remove direct string literals representing passwords or keys from the code, and instead use configuration, environment variables, secret management systems, or clearly marked test-only constants that are not production secrets.

For this specific case in `crates/integration_caldav/src/client.rs`, the value is only used in tests, and functionality should remain unchanged. The best minimal fix is:

- Introduce a test-only constant (e.g., `DUMMY_PASSWORD`) in the test module.
- Replace the inline literal `"dummy-password-for-testing"` with this constant.
- Keep the same string value so all existing assertions and behavior stay identical.

Concretely:

- Inside the existing `#[cfg(test)] mod tests { ... }` block (the snippet around line 716–762 is already inside that module), add a `const DUMMY_PASSWORD: &str = "dummy-password-for-testing";` near the top of the module or just above the tests.
- Update the call to `test_caldav_config` in `caldav_config_debug_redacts_password` to pass `DUMMY_PASSWORD` instead of the literal.
- Update the `assert!` that checks the debug output to check for `DUMMY_PASSWORD` instead of repeating the literal.

No new imports or external crates are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
