### PR TITLE
Potential fix for code scanning alert no. 117: Cleartext logging of sensitive information

### DIFF
--- a/crates/infrastructure/src/config/mod.rs
+++ b/crates/infrastructure/src/config/mod.rs
@@ -1115,10 +1115,8 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(
-            config
-                .app_secret_str()
-                .map(secrecy::ExposeSecret::expose_secret),
-            Some("test_secret")
+            config.app_secret_str(),
+            Some(SecretString::from("test_secret"))
         );
 
         let config_no_secret = WhatsAppConfig::default();


### PR DESCRIPTION
Potential fix for [https://github.com/twohreichel/PiSovereign/security/code-scanning/117](https://github.com/twohreichel/PiSovereign/security/code-scanning/117)

In general, to fix cleartext logging/exposure issues around `SecretString`, avoid converting secrets into raw strings where possible. If exposure is necessary (e.g., to compare with an expected value), keep the comparison within the secrecy abstractions or ensure the secret is never written to logs or other persistent channels.

For this specific test, we can remove the call to `ExposeSecret::expose_secret` entirely and instead compare the returned `Option<SecretString>` against the expected `Option<SecretString>`. This keeps the secret inside the secrecy type and avoids producing a plain `&str`, which is what the analyzer flags as a potential logging sink. Functionality remains the same from the test’s perspective: we still verify that `app_secret_str()` returns the right value and `None` when no secret is configured, but we do it without exposing the secret as a cleartext string.

Concretely:
- In `crates/infrastructure/src/config/mod.rs`, within the `whatsapp_config_app_secret_str` test, replace the `assert_eq!` that calls `.map(secrecy::ExposeSecret::expose_secret)` and compares to `Some("test_secret")` with an `assert_eq!` that compares `config.app_secret_str()` directly to `Some(SecretString::from("test_secret"))`.
- No new imports are necessary; `SecretString` is already imported in that test, and `ExposeSecret` is no longer needed there.
- No other files or methods need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
